### PR TITLE
chore: Use github reference for plugin source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "self-care",
   "version": "1.0.0",
   "description": "Self-Care — Agent trace analysis and context remediation plugin",
@@ -16,7 +15,10 @@
         "name": "Not Diamond",
         "email": "support@notdiamond.ai"
       },
-      "source": ".",
+      "source": {
+        "source": "github",
+        "repo": "Not-Diamond/self-care"
+      },
       "category": "development"
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Updates the plugin source on `marketplace.json` to use a Github reference to the self-care repo.

## Why?

This fixes installation by using a self reference to the plugin source, which is a common pattern for self-contained plugins that are not referenced by an external CC plugin marketplace.

Closes #

## How to test

Install from Claude Code using `/plugin marketplace add Not-Diamond/self-care`

## Checklist

- [x] I've tested this change locally
- [x] I've read the [CONTRIBUTING guidelines](../CONTRIBUTING.md)
